### PR TITLE
Fix https://github.com/rpbouman/huey/issues/125

### DIFF
--- a/src/App/App.js
+++ b/src/App/App.js
@@ -99,11 +99,11 @@ function initApplication(){
   }
  
   bufferEvents(queryModel, 'change', function(event, count){
-    if (count === 0) {
-      return;
+    if (count !== undefined) {
+      return;      
     }
-    console.log(queryModel.getState());
-    console.log(Routing.getRouteForQueryModel(queryModel));
+    console.log(`buffered Events, event:`);
+    console.log(event.eventData);
     Routing.updateRouteFromQueryModel(queryModel);
   }, null, 1000);
  

--- a/src/PageStateManager/PageStateManager.js
+++ b/src/PageStateManager/PageStateManager.js
@@ -1,8 +1,8 @@
 class PageStateManager {
 
   constructor(){
-    //this.#initPopStateHandler();
-    this.#initHashChangeHandler();
+    this.#initPopStateHandler();
+    //this.#initHashChangeHandler();
   }
   
   #initPopStateHandler(){
@@ -22,9 +22,9 @@ class PageStateManager {
   
   // this basically means: load the query
   #popStateHandler(event){
-    var currentRoute = Routing.getCurrentRoute();
+    var newRoute = event.state;
     // TODO: check if the current state already matches the route, if it does we're done.
-    this.setPageState(currentRoute);    
+    this.setPageState(newRoute);    
   }
   
   async chooseDataSourceForPageStateChangeDialog(referencedColumns, desiredDatasourceId, compatibleDatasources){

--- a/src/Routing/Routing.js
+++ b/src/Routing/Routing.js
@@ -53,13 +53,15 @@ class Routing {
   }
 
   static updateRouteFromQueryModel(queryModel){
-    var currentRoute = Routing.getCurrentRoute();
     var newRoute = Routing.getRouteForQueryModel(queryModel);
-    if (currentRoute === newRoute && Boolean(newRoute)) {
-      return;
-    }
+    //if (currentRoute === newRoute && Boolean(newRoute)) {
+    //  return;
+   // }
     var hash = newRoute ? `#${newRoute}` : '';
     //document.location.hash = hash;
-    history.pushState(undefined, undefined, hash);
+    if (history.state === newRoute){
+      return;
+    }
+    history.pushState(newRoute, undefined, hash);
   }
 }

--- a/src/util/event/EventBuffer.js
+++ b/src/util/event/EventBuffer.js
@@ -48,9 +48,14 @@ function bufferEvents(eventEmitter, eventId, handler, scope, timeout){
     }
     else {
       count += 1;
+      // clear the timeout to kick of the final handler call, as we're not done receiving events.
       clearTimeout(timeoutId);
     }
+    // alwayws call the handler with the event and the event count.
+    // This allows the handler to decide after how many events to handle something.
     handler.call(scope ? scope : null, event, count);
+
+    // Set a timeout for the final call to the handler - this kicks in after the timeout after the last event has expired.
     timeoutId = setTimeout(function(){
       timeoutId = undefined;
       handler.call(scope ? scope : null, event);


### PR DESCRIPTION
Problem was that a back request would pop the state, which would lead to a request storm of query model updates. That was not a problem, but we forgot to check the count event passed by the event buffer, so we would repeatedly push the state of intermediate query model states.