### PR TITLE
Fix https://github.com/rpbouman/huey/issues/492

### DIFF
--- a/src/DatasourceSettingsDialog/DatasourceSettings.js
+++ b/src/DatasourceSettingsDialog/DatasourceSettings.js
@@ -1,5 +1,13 @@
 class DatasourceSettings extends SettingsBase {
 
+  static #reader_settings = {
+    'read_csv': 'csvReader',
+    'read_json': 'jsonReader',
+    'read_json_auto': 'jsonReader',
+    'read_parquet': 'parquetReader',
+    'read_xlsx': 'xlsxReader'
+  };
+
   static #template = {
     "csvReader": {
       "csvReaderAutoDetect": true,
@@ -50,6 +58,33 @@ class DatasourceSettings extends SettingsBase {
       "csvReaderDateformat": "",
       "csvReaderTimestampformat": "",
       "csvReaderNullstr": ""
+    },
+    "jsonReader": {
+      "jsonReaderFormat": {
+        "options": [
+          {"value": "auto", "label": "Automatic", "title": "Automatic" },
+          {"value": "unstructured", "label": "Unstructured", "title": "Unstructured" },
+          {"value": "newline_delimited", "label": "Newline delimited", "title": "Delimited by newlines" },
+          {"value": "array", "label": "Array", "title": "Array" },
+        ],
+        "value": "auto"
+      },
+      "jsonReaderMaximumObjectSize": 16777216,
+      "jsonReaderAutoDetect": true,
+      "jsonReaderDateFormat": "iso",
+      "jsonReaderMaximumDepth": -1,
+      "jsonReaderRecords": {
+        "options": [
+          {"value": "auto", "label": "Automatic", "title": "Automatic" },
+          {"value": "true", "label": "True", "title": "True" },
+          {"value": "false", "label": "False", "title": "False" },
+        ]
+      },
+      "jsonReaderSampleSize": 20480,
+      "jsonReaderTimestampformat": "iso",
+      "jsonReaderUnionByName": true,
+      "jsonReaderMapInferenceThreshold": 200,
+      "jsonReaderFieldAppearanceThreshold": 0.1
     }
   };
 
@@ -74,13 +109,17 @@ class DatasourceSettings extends SettingsBase {
     return argumentName;
   }
 
-  getCsvReaderArguments(){
-    var csvReaderArguments = {};
-    var csvReaderKey = 'csvReader';
-    var csvReaderSettings = this.getSettings(csvReaderKey);
-    var templateSettings = DatasourceSettings.#template[csvReaderKey];
-    for (var settingKey in csvReaderSettings){
-      var value = csvReaderSettings[settingKey];
+  getReaderArguments(readerKey){
+    
+    if (DatasourceSettings.#reader_settings[readerKey] !== undefined) {
+      readerKey = DatasourceSettings.#reader_settings[readerKey];
+    }
+    
+    var readerArguments = {};
+    var readerSettings = this.getSettings(readerKey);
+    var templateSettings = DatasourceSettings.#template[readerKey];
+    for (var settingKey in readerSettings){
+      var value = readerSettings[settingKey];
       var templateValue = templateSettings[settingKey];
       var valueIsDefault;
       switch (typeof(value)){
@@ -95,16 +134,16 @@ class DatasourceSettings extends SettingsBase {
           valueIsDefault = value === templateValue;
       }
       if (!valueIsDefault) {
-        var argumentName = DatasourceSettings.#getDuckDbReaderArgumentName(csvReaderKey, settingKey);
-        csvReaderArguments[argumentName] = value;
+        var argumentName = DatasourceSettings.#getDuckDbReaderArgumentName(readerKey, settingKey);
+        readerArguments[argumentName] = value;
       }
     }
-    return csvReaderArguments;
+    return readerArguments;
   }
 
-  static getCsvReaderArgumentsSql(csvReaderArguments){
-    return Object.keys(csvReaderArguments).map(function(argumentName){
-      var argumentValue = csvReaderArguments[argumentName];
+  static getReaderArgumentsSql(readerArguments){
+    return Object.keys(readerArguments).map(function(argumentName){
+      var argumentValue = readerArguments[argumentName];
       switch (typeof(argumentValue)){
         case 'string':
           argumentValue = quoteStringLiteral(argumentValue);

--- a/src/DatasourceSettingsDialog/DatasourceSettingsDialog.js
+++ b/src/DatasourceSettingsDialog/DatasourceSettingsDialog.js
@@ -80,9 +80,9 @@ class DatasourceSettingsDialog extends SettingsDialogBase {
     }
 
     var datasourceSettings = datasource.getSettings();
-    var csvReaderArguments = datasourceSettings.getCsvReaderArguments();
+    var csvReaderArguments = datasourceSettings.getReaderArguments('csvReader');
     //csvReaderArguments['ignore_errors'] = true;
-    var csvReaderArgumentsSql = DatasourceSettings.getCsvReaderArgumentsSql(csvReaderArguments);
+    var csvReaderArgumentsSql = DatasourceSettings.getReaderArgumentsSql(csvReaderArguments);
     if (csvReaderArgumentsSql && csvReaderArgumentsSql.length) {
       csvReaderArgumentsSql = `, ${csvReaderArgumentsSql}`;
     }

--- a/src/UploadUi/UploadUi.js
+++ b/src/UploadUi/UploadUi.js
@@ -61,12 +61,14 @@ class UploadUi {
         progressBar.value = parseInt(progressBar.value, 10) + 40;
       }
 
-      var canAccess = await duckDbDataSource.validateAccess();
+      var tryResult = await duckDbDataSource.tryAccess(100);
+      var isAccessible = tryResult.success;
       progressBar.value = parseInt(progressBar.value, 10) + 30;
 
-      if (canAccess !== true) {
+      if (isAccessible !== true) {
         destroyDatasource = true;
-        throw new Error(`Error uploading file ${file.name}: ${canAccess.message}.`);
+        var errorMessage = tryResult.lastAttempt.message;
+        throw new Error(`Error uploading file ${file.name}: ${errorMessage}.`);
       }
 
       if (duckDbDataSource.getType() === DuckDbDataSource.types.FILE) {


### PR DESCRIPTION
This addes settings for the json reader, and introduces logic that allows a failed attempt to read from the datasource to be retried. The datasource will examine the error message, and might use the error message to adapt or modify its settings, and then retry.

In the case of the json reader returning a '"maximum_object_size" of \d+ bytes exceeded' message, it will extract the '(> \d+ byets)' part from the message, and use that number to retry. This will repeat until either the number of attempts runs out, or DuckDB runs out of memory, in which case the normal failure reporting kicks in.