### PR TITLE
feat: switch bigint to measure

### DIFF
--- a/src/util/sql/SQLHelper.js
+++ b/src/util/sql/SQLHelper.js
@@ -595,7 +595,7 @@ var dataTypes = {
     }
   },
   'BIGINT': {
-    defaultAnalyticalRole: 'attribute',
+    defaultAnalyticalRole: 'measure',
     isNumeric: true,
     isInteger: true,
     greaterPrecisionAlternative: "HUGEINT",
@@ -670,7 +670,7 @@ var dataTypes = {
     }    
   },
   'UBIGINT': {
-    defaultAnalyticalRole: 'attribute',
+    defaultAnalyticalRole: 'measure',
     isNumeric: true,
     isInteger: true,
     isUnsigned: true,


### PR DESCRIPTION
Switches the `defaultAnalyticalRole` for `BIGINT` to `measure`, allowing the user to add the summation aggregation without needing to drill down.