### PR TITLE
Fix undeclared caption assignment in pivot export ORDER BY

### DIFF
--- a/src/ExportUi/ExportDialog.js
+++ b/src/ExportUi/ExportDialog.js
@@ -171,7 +171,7 @@ class ExportUi {
     if (rowsAxisItems.length) {
       const orderBy = rowsAxisItems
       .map(queryAxisItem => {
-        caption = QueryAxisItem.getCaptionForQueryAxisItem(queryAxisItem);
+        let caption = QueryAxisItem.getCaptionForQueryAxisItem(queryAxisItem);
         return quoteIdentifierWhenRequired(caption);
       })
       .join(getComma(options.sqlOptions.commaStyle));


### PR DESCRIPTION
The third .map() callback in getSqlForPivotExport (the one building the ORDER BY clause for rows-axis items) was assigning to `caption` without a declaration. The two earlier callbacks in the same function correctly declare it. Under strict mode this throws `ReferenceError: caption is not defined` whenever a Pivot-shape export runs against a query with rows-axis items.