### PR TITLE
fix issue https://github.com/rpbouman/huey/issues/763

### DIFF
--- a/src/App/App.js
+++ b/src/App/App.js
@@ -134,6 +134,10 @@ function initExecuteQuery(){
   byId('runQueryButton').addEventListener('click', event => {
     pivotTableUi.updatePivotTableUi();
   });
+  
+  byId('sidebarPin').addEventListener('change', event => {
+    Routing.updateRouteFromQueryModel(queryModel);
+  });
 
   const autoRunQuery = byId('autoRunQuery');
   const settingsPath = ['querySettings', 'autoRunQuery'];

--- a/src/PageStateManager/PageStateManager.js
+++ b/src/PageStateManager/PageStateManager.js
@@ -210,6 +210,10 @@ class PageStateManager {
       // TODO: maybe throw an error?
       return;
     }
+    const routeSettings = state.settings;
+    if ( typeof routeSettings.sidebarPin !== undefined) {
+      byId('sidebarPin').checked = Boolean(routeSettings.sidebarPin);
+    }
 
     const queryModelState = state.queryModel;
     const referencedColumns = QueryModel.getReferencedColumns(queryModelState);
@@ -249,6 +253,7 @@ class PageStateManager {
     queryModelState.datasourceId = datasource.getId();
     queryModel.setState(queryModelState);
     analyzeDatasource(datasource);
+    
     const attributeSettings = settings.getSettings('attributeSettings');
     const revealAttributesUsedInQuery = attributeSettings.revealAttributesUsedInQuery;
     if (revealAttributesUsedInQuery) {

--- a/src/Routing/Routing.js
+++ b/src/Routing/Routing.js
@@ -32,7 +32,10 @@ class Routing {
     }
     
     const routeObject = queryModelState.queryModel ? queryModelState : {
-      queryModel: queryModelState 
+      queryModel: queryModelState,
+      settings: {
+        sidebarPin: byId('sidebarPin').checked
+      }
     };
     const json = JSON.stringify( routeObject );
     const ascii = encodeURIComponent( json );


### PR DESCRIPTION
This issue is now fixed. 

To accomodate this, a new ```settings```` key is introduced at the top level page state object.
Inside, the key ```sidebarPin``` can be set to true (expanded) or false (collapsed).

Example:

```
{
  "queryModel": {
    "datasourceId": "file:\"fhvhv_tripdata_2023-01.parquet\"",
    "cellsHeaders": "columns",
    "axes": {
      "cells": [
        {
          "columnName": "*",
          "columnType": "INTEGER",
          "aggregator": "count"
        }
      ],
      "rows": [
        {
          "columnName": "hvfhs_license_num",
          "columnType": "VARCHAR"
        },
        {
          "columnName": "dispatching_base_num",
          "columnType": "VARCHAR"
        }
      ]
    }
  },
  "settings": {
    "sidebarPin": true
  }
}
```